### PR TITLE
Initial SwiftUI app skeleton for Spotlight Downloader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Clipper",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "ClipperApp", targets: ["ClipperApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClipperApp",
+            dependencies: [
+                .product(name: "OrderedCollections", package: "swift-collections")
+            ],
+            path: "Sources/ClipperApp",
+            resources: [
+                .process("Resources")
+            ]
+        ),
+        .testTarget(
+            name: "ClipperAppTests",
+            dependencies: ["ClipperApp"],
+            path: "Tests/ClipperAppTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -65,3 +65,30 @@
       * **완화 전략:**
         1.  앱 내에 "본 앱은 기술적인 도구이며, 다운로드하는 콘텐츠에 대한 책임은 전적으로 사용자에게 있습니다"라는 내용의 면책 조항 명시.
         2.  저작권 보호(DRM)가 적용된 콘텐츠는 다운로드할 수 없음을 명확히 안내.
+
+---
+
+## 구현 개요 (Implementation Overview)
+
+Spotlight Downloader의 초기 구현은 Swift Package Manager 기반의 macOS 전용 SwiftUI 애플리케이션으로 구성되어 있습니다. 프로젝트를 Xcode에서 열면 SwiftUI App 구조를 이용해 메인 UI, 다운로드 큐 관리, 설정 화면을 모두 확인할 수 있습니다.
+
+### 주요 모듈
+
+| 모듈 | 설명 |
+| --- | --- |
+| `DownloadManager` | `yt-dlp`/`ffmpeg` 프로세스를 제어하며 다운로드 진행률 파싱, 큐 관리, 완료/실패 알림을 처리합니다. |
+| `PreferenceStore` | 사용자 기본 설정(저장 위치, 포맷 선호도 등)을 `UserDefaults`와 번들 JSON 기본값을 통해 관리합니다. |
+| `DownloadQueueViewModel` | 대기열/진행 중/완료 목록을 UI에 전달하고 Spotlight 또는 수동 입력으로부터 다운로드 요청을 처리합니다. |
+| `SpotlightBridge` | Spotlight File Provider 확장과의 통신을 위한 알림 브리지를 제공하여 URL을 앱으로 전달합니다. |
+| `NotificationManager` | macOS 사용자 알림 센터를 통해 다운로드 완료/실패 피드백을 제공합니다. |
+
+### 빌드 & 실행 방법
+
+1. 저장소를 클론한 뒤 `Clipper` 디렉터리를 Xcode 15 이상에서 엽니다.
+2. 필요 시 `yt-dlp`와 `ffmpeg` 실행 파일을 `Sources/ClipperApp/Resources` 디렉터리에 추가하거나 `DownloadToolchain`이 찾을 수 있는 시스템 경로에 설치합니다.
+3. `ClipperApp` 실행 대상(Target)을 선택하고 빌드/실행하면 기본 UI가 나타납니다.
+4. Spotlight 확장을 연동하려면 별도의 `Spotlight` Extension Target을 추가하고 `SpotlightBridge.notificationName`을 통해 URL을 전달하도록 구성합니다.
+
+### 테스트
+
+SwiftUI 및 AppKit 의존성으로 인해 Linux 환경에서는 테스트가 실행되지 않습니다. macOS 환경에서 `swift test` 또는 Xcode의 Test 동작을 사용해 `ClipperAppTests`를 실행할 수 있습니다.

--- a/Sources/ClipperApp/App/AppDependencies.swift
+++ b/Sources/ClipperApp/App/AppDependencies.swift
@@ -1,0 +1,41 @@
+import Combine
+import Foundation
+import SwiftUI
+
+@MainActor
+final class AppDependencies: ObservableObject {
+    let preferenceStore: PreferenceStore
+    let downloadManager: DownloadManager
+    let downloadQueueViewModel: DownloadQueueViewModel
+    let settingsViewModel: SettingsViewModel
+    private let spotlightBridge: SpotlightBridge
+    private let notificationManager: NotificationManager
+
+    init() {
+        let preferenceStore = PreferenceStore()
+        self.preferenceStore = preferenceStore
+
+        let notificationManager = NotificationManager.shared
+        self.notificationManager = notificationManager
+        notificationManager.requestAuthorization()
+
+        let downloadManager = DownloadManager(preferenceStore: preferenceStore,
+                                              notificationManager: notificationManager)
+        self.downloadManager = downloadManager
+
+        let queueViewModel = DownloadQueueViewModel(manager: downloadManager,
+                                                    preferenceStore: preferenceStore)
+        self.downloadQueueViewModel = queueViewModel
+
+        let settingsViewModel = SettingsViewModel(preferenceStore: preferenceStore)
+        self.settingsViewModel = settingsViewModel
+
+        self.spotlightBridge = SpotlightBridge { url in
+            Task { [weak downloadManager] in
+                await downloadManager?.handleIncoming(url: url)
+            }
+        }
+
+        self.spotlightBridge.start()
+    }
+}

--- a/Sources/ClipperApp/App/ClipperApp.swift
+++ b/Sources/ClipperApp/App/ClipperApp.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+@main
+struct ClipperApp: App {
+    @StateObject private var dependencies = AppDependencies()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView(viewModel: dependencies.downloadQueueViewModel,
+                        settingsViewModel: dependencies.settingsViewModel)
+                .environmentObject(dependencies.downloadQueueViewModel)
+                .environmentObject(dependencies.settingsViewModel)
+        }
+        .windowStyle(.automatic)
+        .defaultSize(width: 960, height: 620)
+
+        Settings {
+            SettingsView(viewModel: dependencies.settingsViewModel)
+                .frame(width: 480, height: 360)
+        }
+    }
+}

--- a/Sources/ClipperApp/Models/DownloadConfiguration.swift
+++ b/Sources/ClipperApp/Models/DownloadConfiguration.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct DownloadConfiguration: Codable, Equatable {
+    enum FormatPreference: String, Codable, CaseIterable, Identifiable {
+        case best
+        case highDefinition
+        case audioOnly
+        case askEveryTime
+
+        var id: String { rawValue }
+
+        var ytDlpFormatIdentifier: String {
+            switch self {
+            case .best: return "best"
+            case .highDefinition: return "bestvideo[height<=1080]+bestaudio/best"
+            case .audioOnly: return "bestaudio/best"
+            case .askEveryTime: return "best"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .best:
+                return "최고 화질 (가능한 최고 해상도의 영상과 오디오)"
+            case .highDefinition:
+                return "1080p 이하의 고화질 영상"
+            case .audioOnly:
+                return "오디오만 추출 (M4A)"
+            case .askEveryTime:
+                return "항상 포맷 선택"
+            }
+        }
+    }
+
+    var downloadDirectory: URL
+    var formatPreference: FormatPreference
+    var shouldPromptForFormat: Bool
+
+    static let `default`: DownloadConfiguration = {
+        let directory = FileManager.default
+            .homeDirectoryForCurrentUser
+            .appending(path: "Downloads/SpotlightDownloader", directoryHint: .isDirectory)
+        return .init(downloadDirectory: directory,
+                     formatPreference: .best,
+                     shouldPromptForFormat: false)
+    }()
+}

--- a/Sources/ClipperApp/Models/DownloadRequest.swift
+++ b/Sources/ClipperApp/Models/DownloadRequest.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct DownloadRequest {
+    enum Source {
+        case spotlight
+        case manual
+    }
+
+    let url: URL
+    var format: String
+    var mediaType: DownloadTask.MediaType
+    var customTitle: String?
+    var source: Source
+
+    init(url: URL,
+         format: String,
+         mediaType: DownloadTask.MediaType = .video,
+         customTitle: String? = nil,
+         source: Source = .manual) {
+        self.url = url
+        self.format = format
+        self.mediaType = mediaType
+        self.customTitle = customTitle
+        self.source = source
+    }
+}

--- a/Sources/ClipperApp/Models/DownloadState.swift
+++ b/Sources/ClipperApp/Models/DownloadState.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum DownloadState: Equatable {
+    case queued
+    case preparing
+    case downloading(progress: Double, eta: TimeInterval?)
+    case finished(fileURL: URL)
+    case failed(reason: String)
+    case cancelled
+
+    var isTerminal: Bool {
+        switch self {
+        case .finished, .failed, .cancelled:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var progress: Double {
+        switch self {
+        case let .downloading(progress, _):
+            return progress
+        case .finished:
+            return 1.0
+        default:
+            return 0.0
+        }
+    }
+}

--- a/Sources/ClipperApp/Models/DownloadTask.swift
+++ b/Sources/ClipperApp/Models/DownloadTask.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct DownloadTask: Identifiable, Equatable {
+    enum MediaType: String, Codable, CaseIterable, Identifiable {
+        case video
+        case audio
+
+        var id: String { rawValue }
+    }
+
+    let id: UUID
+    let url: URL
+    var title: String
+    var thumbnailURL: URL?
+    var createdAt: Date
+    var state: DownloadState
+    var formatIdentifier: String
+    var mediaType: MediaType
+    var destinationURL: URL?
+
+    init(id: UUID = UUID(),
+         url: URL,
+         title: String = "",
+         thumbnailURL: URL? = nil,
+         createdAt: Date = .init(),
+         state: DownloadState = .queued,
+         formatIdentifier: String = "best",
+         mediaType: MediaType = .video,
+         destinationURL: URL? = nil) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.thumbnailURL = thumbnailURL
+        self.createdAt = createdAt
+        self.state = state
+        self.formatIdentifier = formatIdentifier
+        self.mediaType = mediaType
+        self.destinationURL = destinationURL
+    }
+
+    static func == (lhs: DownloadTask, rhs: DownloadTask) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Sources/ClipperApp/Models/FormatDescriptor.swift
+++ b/Sources/ClipperApp/Models/FormatDescriptor.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct FormatDescriptor: Identifiable, Equatable {
+    let id: String
+    let description: String
+    let fileExtension: String
+    let resolution: String
+    let note: String
+
+    init(id: String, description: String, fileExtension: String, resolution: String, note: String) {
+        self.id = id
+        self.description = description
+        self.fileExtension = fileExtension
+        self.resolution = resolution
+        self.note = note
+    }
+}

--- a/Sources/ClipperApp/Resources/default-preferences.json
+++ b/Sources/ClipperApp/Resources/default-preferences.json
@@ -1,0 +1,5 @@
+{
+  "downloadDirectory": "~/Downloads/SpotlightDownloader",
+  "preferredFormat": "best",
+  "autoPromptFormat": false
+}

--- a/Sources/ClipperApp/Services/DownloadManager.swift
+++ b/Sources/ClipperApp/Services/DownloadManager.swift
@@ -1,0 +1,345 @@
+import Combine
+import Foundation
+import OrderedCollections
+
+@MainActor
+final class DownloadManager: ObservableObject {
+    @Published private(set) var queuedTasks: OrderedDictionary<UUID, DownloadTask> = [:]
+    @Published private(set) var activeTasks: OrderedDictionary<UUID, DownloadTask> = [:]
+    @Published private(set) var completedTasks: OrderedDictionary<UUID, DownloadTask> = [:]
+
+    private let preferenceStore: PreferenceStore
+    private let notificationManager: NotificationManager?
+    private let workerQueue = DispatchQueue(label: "com.spotlightdownloader.clipper.download", qos: .userInitiated)
+    private var processes: [UUID: Process] = [:]
+    private var outputBuffers: [UUID: String] = [:]
+    private var toolchain: DownloadToolchain?
+    private let maxConcurrentDownloads = 2
+
+    init(preferenceStore: PreferenceStore, notificationManager: NotificationManager? = nil) {
+        self.preferenceStore = preferenceStore
+        self.notificationManager = notificationManager
+        Task { [weak self] in
+            await self?.refreshToolchain()
+        }
+    }
+
+    func handleIncoming(url: URL) async {
+        let configuration = preferenceStore.configuration
+        let format = configuration.formatPreference.ytDlpFormatIdentifier
+        let mediaType: DownloadTask.MediaType = configuration.formatPreference == .audioOnly ? .audio : .video
+        let request = DownloadRequest(url: url, format: format, mediaType: mediaType, source: .spotlight)
+        enqueue(request: request)
+    }
+
+    @discardableResult
+    func enqueue(request: DownloadRequest) -> DownloadTask {
+        var task = DownloadTask(url: request.url,
+                                title: request.customTitle ?? request.url.absoluteString,
+                                state: .queued,
+                                formatIdentifier: request.format,
+                                mediaType: request.mediaType)
+        queuedTasks[task.id] = task
+        Logger.download.info("Enqueued download: \(task.url)")
+        fetchMetadata(for: task.id, url: task.url)
+        processQueue()
+        return task
+    }
+
+    func cancel(taskID: UUID) {
+        if let process = processes[taskID] {
+            process.terminate()
+            processes[taskID] = nil
+        }
+        if var task = activeTasks[taskID] {
+            task.state = .cancelled
+            activeTasks[taskID] = nil
+            completedTasks[taskID] = task
+        } else if queuedTasks[taskID] != nil {
+            var task = queuedTasks.removeValue(forKey: taskID)
+            task?.state = .cancelled
+            if let task { completedTasks[task.id] = task }
+        }
+        processQueue()
+    }
+
+    func retry(taskID: UUID) {
+        guard let completed = completedTasks[taskID] else { return }
+        var retried = completed
+        retried.state = .queued
+        retried.destinationURL = nil
+        completedTasks[taskID] = nil
+        queuedTasks[retried.id] = retried
+        processQueue()
+    }
+
+    func removeCompleted(taskID: UUID) {
+        completedTasks[taskID] = nil
+    }
+
+    func clearCompleted() {
+        completedTasks.removeAll()
+    }
+
+    func refreshToolchain() async {
+        do {
+            self.toolchain = try DownloadToolchain(bundle: .main)
+        } catch {
+            Logger.download.error("Toolchain discovery failed: \(error.localizedDescription)")
+        }
+    }
+
+    func availableFormats(for url: URL) async throws -> [FormatDescriptor] {
+        let toolchain = try toolchainOrThrow()
+        return try await withCheckedThrowingContinuation { continuation in
+            workerQueue.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: [])
+                    return
+                }
+                let process = Process()
+                process.executableURL = toolchain.ytDlpURL
+                process.arguments = ["--list-formats", url.absoluteString]
+                let pipe = Pipe()
+                process.standardOutput = pipe
+                process.standardError = Pipe()
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                process.terminationHandler = { _ in
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let output = String(decoding: data, as: UTF8.self)
+                    let formats = self.parseFormats(from: output)
+                    continuation.resume(returning: formats)
+                }
+            }
+        }
+    }
+
+    private func processQueue() {
+        while activeTasks.count < maxConcurrentDownloads, let next = queuedTasks.first {
+            queuedTasks[next.key] = nil
+            var task = next.value
+            task.state = .preparing
+            activeTasks[task.id] = task
+            start(task: task)
+        }
+    }
+
+    private func start(task: DownloadTask) {
+        guard let toolchain = try? toolchainOrThrow() else {
+            markFailure(taskID: task.id, reason: "다운로드 도구를 찾을 수 없습니다.")
+            return
+        }
+
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            let process = Process()
+            process.executableURL = toolchain.ytDlpURL
+            var arguments = ["--newline",
+                             "--no-mtime"]
+            if let ffmpegURL = toolchain.ffmpegURL {
+                arguments += ["--ffmpeg-location", ffmpegURL.path]
+            }
+            arguments += ["-f", task.formatIdentifier,
+                          "-o", self.outputTemplate(for: task),
+                          task.url.absoluteString]
+            process.arguments = arguments
+
+            let pipe = Pipe()
+            process.standardError = pipe
+            process.standardOutput = Pipe()
+            self.processes[task.id] = process
+            self.outputBuffers[task.id] = ""
+
+            pipe.fileHandleForReading.readabilityHandler = { handle in
+                self?.handleOutput(for: task.id, data: handle.availableData)
+            }
+
+            process.terminationHandler = { process in
+                pipe.fileHandleForReading.readabilityHandler = nil
+                self?.handleTermination(of: task.id, process: process)
+            }
+
+            do {
+                try process.run()
+                Logger.download.info("Started yt-dlp for \(task.url)")
+                Task { @MainActor [weak self] in
+                    self?.update(taskID: task.id) { task in
+                        task.state = .downloading(progress: 0, eta: nil)
+                    }
+                }
+            } catch {
+                Task { @MainActor [weak self] in
+                    self?.markFailure(taskID: task.id, reason: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    private func handleOutput(for taskID: UUID, data: Data) {
+        guard !data.isEmpty else { return }
+        let chunk = String(decoding: data, as: UTF8.self)
+        outputBuffers[taskID, default: ""] += chunk
+        var buffer = outputBuffers[taskID] ?? ""
+        while let range = buffer.range(of: "\n") {
+            let line = String(buffer[..<range.lowerBound])
+            buffer = String(buffer[range.upperBound...])
+            parse(line: line, for: taskID)
+        }
+        outputBuffers[taskID] = buffer
+    }
+
+    private func parse(line: String, for taskID: UUID) {
+        if let match = YTDLPProgressParser.parseProgress(from: line) {
+            Task { @MainActor [weak self] in
+                self?.update(taskID: taskID) { task in
+                    task.state = .downloading(progress: match.progress, eta: match.eta)
+                }
+            }
+        } else if line.contains("Destination:") {
+            let components = line.split(separator: " ", maxSplits: 1).map(String.init)
+            if components.count == 2 {
+                let path = components[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                let url = URL(fileURLWithPath: path)
+                Task { @MainActor [weak self] in
+                    self?.update(taskID: taskID) { task in
+                        task.destinationURL = url
+                    }
+                }
+            }
+        }
+    }
+
+    private func fetchMetadata(for taskID: UUID, url: URL) {
+        workerQueue.async { [weak self] in
+            guard let self else { return }
+            guard let toolchain = try? self.toolchainOrThrow() else { return }
+            let process = Process()
+            process.executableURL = toolchain.ytDlpURL
+            process.arguments = ["--skip-download", "--print-json", url.absoluteString]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+            } catch {
+                Logger.download.error("Metadata fetch failed to start: \(error.localizedDescription)")
+                return
+            }
+
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard
+                let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+
+            let title = jsonObject["title"] as? String
+            let thumbnailString = jsonObject["thumbnail"] as? String
+            let parsedThumbnail = thumbnailString.flatMap { URL(string: $0) }
+
+            Task { @MainActor [weak self] in
+                self?.update(taskID: taskID) { task in
+                    if let title {
+                        task.title = title
+                    }
+                    task.thumbnailURL = parsedThumbnail
+                }
+            }
+        }
+    }
+
+    private func handleTermination(of taskID: UUID, process: Process) {
+        Task { @MainActor in
+            self.processes[taskID] = nil
+            let terminationReason = process.terminationReason
+            if process.terminationStatus == 0 {
+                if var task = activeTasks.removeValue(forKey: taskID) {
+                    if case let .downloading(_, _) = task.state,
+                       let destination = task.destinationURL {
+                        task.state = .finished(fileURL: destination)
+                    } else {
+                        task.state = .finished(fileURL: preferenceStore.configuration.downloadDirectory)
+                    }
+                    completedTasks[taskID] = task
+                    Logger.download.info("Finished download: \(task.url)")
+                    notificationManager?.postCompletionNotification(for: task)
+                }
+            } else {
+                let reason = "다운로드 실패 (코드: \(process.terminationStatus), 이유: \(terminationReason.rawValue))"
+                markFailure(taskID: taskID, reason: reason)
+            }
+            processQueue()
+        }
+    }
+
+    private func markFailure(taskID: UUID, reason: String) {
+        if var task = activeTasks.removeValue(forKey: taskID) {
+            task.state = .failed(reason: reason)
+            completedTasks[taskID] = task
+            notificationManager?.postFailureNotification(for: task, reason: reason)
+        } else if var queued = queuedTasks.removeValue(forKey: taskID) {
+            queued.state = .failed(reason: reason)
+            completedTasks[taskID] = queued
+            notificationManager?.postFailureNotification(for: queued, reason: reason)
+        } else if var existing = completedTasks[taskID] {
+            existing.state = .failed(reason: reason)
+            completedTasks[taskID] = existing
+            notificationManager?.postFailureNotification(for: existing, reason: reason)
+        }
+        Logger.download.error("Task \(taskID) failed: \(reason)")
+        processQueue()
+    }
+
+    private func update(taskID: UUID, mutation: (inout DownloadTask) -> Void) {
+        if var task = activeTasks[taskID] {
+            mutation(&task)
+            activeTasks[taskID] = task
+        } else if var task = queuedTasks[taskID] {
+            mutation(&task)
+            queuedTasks[taskID] = task
+        } else if var task = completedTasks[taskID] {
+            mutation(&task)
+            completedTasks[taskID] = task
+        }
+    }
+
+    private func outputTemplate(for task: DownloadTask) -> String {
+        let directory = preferenceStore.configuration.downloadDirectory
+        let filename = "%(title)s.%(ext)s"
+        return directory.appendingPathComponent(filename).path
+    }
+
+    private func toolchainOrThrow() throws -> DownloadToolchain {
+        if let toolchain { return toolchain }
+        let resolved = try DownloadToolchain(bundle: .main)
+        self.toolchain = resolved
+        return resolved
+    }
+
+    private func parseFormats(from output: String) -> [FormatDescriptor] {
+        let lines = output.split(separator: "\n").map(String.init)
+        guard let headerIndex = lines.firstIndex(where: { $0.contains("format code") }) else { return [] }
+        let formatLines = lines[(headerIndex + 1)...]
+        return formatLines.compactMap { line -> FormatDescriptor? in
+            let components = line.split(separator: " ", maxSplits: 4, omittingEmptySubsequences: true).map(String.init)
+            guard components.count >= 4 else { return nil }
+            let id = components[0]
+            let extensionComponent = components[1]
+            let resolution = components[2]
+            let note = components[3...].joined(separator: " ")
+            let description = "\(id) • \(resolution) • \(note)"
+            return FormatDescriptor(id: id,
+                                    description: description,
+                                    fileExtension: extensionComponent,
+                                    resolution: resolution,
+                                    note: note)
+        }
+    }
+}

--- a/Sources/ClipperApp/Services/DownloadToolchain.swift
+++ b/Sources/ClipperApp/Services/DownloadToolchain.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum DownloadToolchainError: Error, LocalizedError {
+    case missingExecutable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingExecutable(name):
+            return "\(name) 실행 파일을 찾을 수 없습니다. 앱 설정에서 번들 파일을 확인해 주세요."
+        }
+    }
+}
+
+struct DownloadToolchain {
+    let ytDlpURL: URL
+    let ffmpegURL: URL?
+
+    init(bundle: Bundle = .main) throws {
+        self.ytDlpURL = try DownloadToolchain.locateExecutable(named: "yt-dlp", in: bundle)
+        self.ffmpegURL = try? DownloadToolchain.locateExecutable(named: "ffmpeg", in: bundle)
+    }
+
+    static func locateExecutable(named name: String, in bundle: Bundle) throws -> URL {
+        let possibleNames = [name, name + "-macos"]
+        for candidate in possibleNames {
+            if let bundled = bundle.url(forResource: candidate, withExtension: nil) ?? Bundle.module.url(forResource: candidate, withExtension: nil) {
+                return bundled
+            }
+        }
+
+        let searchPaths = ["/usr/local/bin/\(name)", "/opt/homebrew/bin/\(name)", "/opt/local/bin/\(name)", "/usr/bin/\(name)"]
+        if let path = searchPaths.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return URL(fileURLWithPath: path)
+        }
+
+        throw DownloadToolchainError.missingExecutable(name)
+    }
+}

--- a/Sources/ClipperApp/Services/NotificationManager.swift
+++ b/Sources/ClipperApp/Services/NotificationManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+import UserNotifications
+
+@MainActor
+final class NotificationManager: ObservableObject {
+    static let shared = NotificationManager()
+
+    private init() {}
+
+    func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error {
+                Logger.general.error("Notification authorization failed: \(error.localizedDescription)")
+            } else {
+                Logger.general.debug("Notification authorization granted: \(granted)")
+            }
+        }
+    }
+
+    func postCompletionNotification(for task: DownloadTask) {
+        let content = UNMutableNotificationContent()
+        content.title = "다운로드 완료"
+        content.body = task.title.isEmpty ? task.url.lastPathComponent : task.title
+        content.sound = .default
+
+        if case let .finished(fileURL) = task.state {
+            let userInfo = ["fileURL": fileURL.path]
+            content.userInfo = userInfo
+        }
+
+        let request = UNNotificationRequest(identifier: task.id.uuidString,
+                                            content: content,
+                                            trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                Logger.general.error("Failed to post completion notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func postFailureNotification(for task: DownloadTask, reason: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "다운로드 실패"
+        content.body = reason
+        content.sound = .defaultCritical
+
+        let request = UNNotificationRequest(identifier: task.id.uuidString + ".failure",
+                                            content: content,
+                                            trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                Logger.general.error("Failed to post failure notification: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Sources/ClipperApp/Services/PreferenceStore.swift
+++ b/Sources/ClipperApp/Services/PreferenceStore.swift
@@ -1,0 +1,105 @@
+import Combine
+import Foundation
+
+@MainActor
+final class PreferenceStore: ObservableObject {
+    @Published private(set) var configuration: DownloadConfiguration
+
+    private enum StorageKeys {
+        static let configuration = "clipper.configuration"
+    }
+
+    private let userDefaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+
+        if let stored = userDefaults.data(forKey: StorageKeys.configuration),
+           let decoded = try? decoder.decode(CodableConfiguration.self, from: stored) {
+            self.configuration = decoded.model
+        } else if let bundledConfiguration = PreferenceStore.loadBundledConfiguration() {
+            self.configuration = bundledConfiguration
+        } else {
+            self.configuration = .default
+        }
+
+        ensureDownloadDirectoryExists()
+    }
+
+    func update(_ block: (inout DownloadConfiguration) -> Void) {
+        block(&configuration)
+        persist()
+    }
+
+    func setDownloadDirectory(_ url: URL) {
+        update { configuration in
+            configuration.downloadDirectory = url
+        }
+        ensureDownloadDirectoryExists()
+    }
+
+    func setFormatPreference(_ preference: DownloadConfiguration.FormatPreference) {
+        update { configuration in
+            configuration.formatPreference = preference
+            configuration.shouldPromptForFormat = (preference == .askEveryTime)
+        }
+    }
+
+    func setPromptForFormat(_ newValue: Bool) {
+        update { configuration in
+            configuration.shouldPromptForFormat = newValue
+        }
+    }
+
+    private func persist() {
+        let codable = CodableConfiguration(model: configuration)
+        if let data = try? encoder.encode(codable) {
+            userDefaults.set(data, forKey: StorageKeys.configuration)
+        }
+    }
+
+    private func ensureDownloadDirectoryExists() {
+        let directory = configuration.downloadDirectory
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            Logger.general.error("Failed to create download directory: \(error.localizedDescription)")
+        }
+    }
+
+    private static func loadBundledConfiguration() -> DownloadConfiguration? {
+        guard let resourceURL = Bundle.module.url(forResource: "default-preferences", withExtension: "json") else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: resourceURL)
+            let dto = try JSONDecoder().decode(CodableConfiguration.self, from: data)
+            return dto.model
+        } catch {
+            Logger.general.error("Failed to decode bundled configuration: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}
+
+private struct CodableConfiguration: Codable {
+    var downloadDirectory: String
+    var preferredFormat: DownloadConfiguration.FormatPreference
+    var autoPromptFormat: Bool
+
+    init(model: DownloadConfiguration) {
+        self.downloadDirectory = model.downloadDirectory.path
+        self.preferredFormat = model.formatPreference
+        self.autoPromptFormat = model.shouldPromptForFormat
+    }
+
+    var model: DownloadConfiguration {
+        let url = URL(fileURLWithPath: downloadDirectory).standardizedFileURL
+        return DownloadConfiguration(downloadDirectory: url,
+                                     formatPreference: preferredFormat,
+                                     shouldPromptForFormat: autoPromptFormat)
+    }
+}

--- a/Sources/ClipperApp/Services/SpotlightBridge.swift
+++ b/Sources/ClipperApp/Services/SpotlightBridge.swift
@@ -1,0 +1,35 @@
+import Foundation
+import AppKit
+
+final class SpotlightBridge {
+    static let notificationName = Notification.Name("com.spotlightdownloader.clipper.url")
+
+    private let handler: (URL) -> Void
+    private var observer: Any?
+
+    init(handler: @escaping (URL) -> Void) {
+        self.handler = handler
+    }
+
+    func start() {
+        observer = DistributedNotificationCenter.default.addObserver(forName: Self.notificationName,
+                                                                      object: nil,
+                                                                      queue: .main) { [weak self] notification in
+            guard let urlString = notification.userInfo?["url"] as? String,
+                  let url = URL(string: urlString) else { return }
+            Logger.spotlight.info("Received URL from Spotlight: \(url.absoluteString)")
+            self?.handler(url)
+        }
+    }
+
+    func stop() {
+        if let observer {
+            DistributedNotificationCenter.default.removeObserver(observer)
+            self.observer = nil
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/Sources/ClipperApp/Utilities/Logger.swift
+++ b/Sources/ClipperApp/Utilities/Logger.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum Logger {
+    static let subsystem = "com.spotlightdownloader.clipper"
+
+    static let general = LogCategory(name: "general")
+    static let download = LogCategory(name: "download")
+    static let spotlight = LogCategory(name: "spotlight")
+
+    struct LogCategory {
+        let name: String
+
+        func info(_ message: String) {
+            #if DEBUG
+            print("[INFO][\(Logger.subsystem).\(name)] \(message)")
+            #endif
+        }
+
+        func error(_ message: String) {
+            print("[ERROR][\(Logger.subsystem).\(name)] \(message)")
+        }
+
+        func debug(_ message: String) {
+            #if DEBUG
+            print("[DEBUG][\(Logger.subsystem).\(name)] \(message)")
+            #endif
+        }
+    }
+}

--- a/Sources/ClipperApp/Utilities/YTDLPProgressParser.swift
+++ b/Sources/ClipperApp/Utilities/YTDLPProgressParser.swift
@@ -1,31 +1,23 @@
 import Foundation
 
 struct YTDLPProgressParser {
-    private static let progressRegularExpression = try? NSRegularExpression(
-        pattern: "(?:(?:\[download\]\s+)|(?:\s))(?:(\d{1,3}\.\d)%).*?ETA\s+([\d:]+)",
-        options: [.dotMatchesLineSeparators]
-    )
-
     static func parseProgress(from line: String) -> (progress: Double, eta: TimeInterval?)? {
-        guard let regex = progressRegularExpression else { return nil }
-        let range = NSRange(location: 0, length: line.utf16.count)
-        guard let match = regex.firstMatch(in: line, options: [], range: range) else { return nil }
+        let tokens = line.split { $0.isWhitespace }
 
-        var extractedProgress: Double?
+        guard let percentToken = tokens.first(where: { $0.hasSuffix("%") }),
+              let progressValue = Double(percentToken.dropLast()) else {
+            return nil
+        }
+
         var etaValue: TimeInterval?
-
-        if match.numberOfRanges > 1,
-           let progressRange = Range(match.range(at: 1), in: line) {
-            extractedProgress = Double(line[progressRange])
+        if let etaIndex = tokens.firstIndex(where: { $0 == "ETA" }) {
+            let nextIndex = tokens.index(after: etaIndex)
+            if nextIndex < tokens.endIndex {
+                etaValue = timeInterval(for: String(tokens[nextIndex]))
+            }
         }
 
-        if match.numberOfRanges > 2,
-           let etaRange = Range(match.range(at: 2), in: line) {
-            etaValue = timeInterval(for: String(line[etaRange]))
-        }
-
-        guard let progress = extractedProgress else { return nil }
-        return (progress / 100.0, etaValue)
+        return (progressValue / 100.0, etaValue)
     }
 
     private static func timeInterval(for etaString: String) -> TimeInterval? {

--- a/Sources/ClipperApp/Utilities/YTDLPProgressParser.swift
+++ b/Sources/ClipperApp/Utilities/YTDLPProgressParser.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+struct YTDLPProgressParser {
+    private static let progressRegularExpression = try? NSRegularExpression(
+        pattern: "(?:(?:\[download\]\s+)|(?:\s))(?:(\d{1,3}\.\d)%).*?ETA\s+([\d:]+)",
+        options: [.dotMatchesLineSeparators]
+    )
+
+    static func parseProgress(from line: String) -> (progress: Double, eta: TimeInterval?)? {
+        guard let regex = progressRegularExpression else { return nil }
+        let range = NSRange(location: 0, length: line.utf16.count)
+        guard let match = regex.firstMatch(in: line, options: [], range: range) else { return nil }
+
+        var extractedProgress: Double?
+        var etaValue: TimeInterval?
+
+        if match.numberOfRanges > 1,
+           let progressRange = Range(match.range(at: 1), in: line) {
+            extractedProgress = Double(line[progressRange])
+        }
+
+        if match.numberOfRanges > 2,
+           let etaRange = Range(match.range(at: 2), in: line) {
+            etaValue = timeInterval(for: String(line[etaRange]))
+        }
+
+        guard let progress = extractedProgress else { return nil }
+        return (progress / 100.0, etaValue)
+    }
+
+    private static func timeInterval(for etaString: String) -> TimeInterval? {
+        let components = etaString.split(separator: ":").compactMap { Double($0) }
+        guard !components.isEmpty else { return nil }
+        let reversed = components.reversed()
+        var multiplier: Double = 1
+        var total: Double = 0
+        for value in reversed {
+            total += value * multiplier
+            multiplier *= 60
+        }
+        return total
+    }
+}

--- a/Sources/ClipperApp/ViewModels/DownloadQueueViewModel.swift
+++ b/Sources/ClipperApp/ViewModels/DownloadQueueViewModel.swift
@@ -1,0 +1,117 @@
+import AppKit
+import Combine
+import Foundation
+
+@MainActor
+final class DownloadQueueViewModel: ObservableObject {
+    @Published private(set) var queued: [DownloadTask] = []
+    @Published private(set) var active: [DownloadTask] = []
+    @Published private(set) var completed: [DownloadTask] = []
+
+    @Published var urlInput: String = ""
+    @Published var isShowingFormatSheet: Bool = false
+    @Published var availableFormats: [FormatDescriptor] = []
+    @Published var selectedFormat: FormatDescriptor?
+    @Published var formatPreviewTitle: String = ""
+    @Published var pendingFormatURL: URL?
+
+    private let manager: DownloadManager
+    private let preferenceStore: PreferenceStore
+    init(manager: DownloadManager, preferenceStore: PreferenceStore) {
+        self.manager = manager
+        self.preferenceStore = preferenceStore
+
+        manager.$queuedTasks
+            .map { Array($0.values) }
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$queued)
+
+        manager.$activeTasks
+            .map { Array($0.values) }
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$active)
+
+        manager.$completedTasks
+            .map { Array($0.values).sorted { $0.createdAt > $1.createdAt } }
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$completed)
+    }
+
+    func submitURL() {
+        let trimmed = urlInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed), !trimmed.isEmpty else { return }
+
+        if preferenceStore.configuration.shouldPromptForFormat {
+            Task {
+                await loadFormats(for: url)
+            }
+        } else {
+            let format = preferenceStore.configuration.formatPreference.ytDlpFormatIdentifier
+            enqueue(url: url, format: format)
+        }
+
+        urlInput = ""
+    }
+
+    func enqueue(url: URL, format: String, mediaType: DownloadTask.MediaType? = nil) {
+        let mediaType = mediaType ?? (format.contains("audio") ? .audio : .video)
+        let request = DownloadRequest(url: url,
+                                      format: format,
+                                      mediaType: mediaType,
+                                      source: .manual)
+        manager.enqueue(request: request)
+    }
+
+    func cancel(task: DownloadTask) {
+        manager.cancel(taskID: task.id)
+    }
+
+    func retry(task: DownloadTask) {
+        manager.retry(taskID: task.id)
+    }
+
+    func remove(task: DownloadTask) {
+        manager.removeCompleted(taskID: task.id)
+    }
+
+    func clearHistory() {
+        manager.clearCompleted()
+    }
+
+    func openInFinder(task: DownloadTask) {
+        guard case let .finished(fileURL) = task.state else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+    }
+
+    func showFormatSheet(for url: URL) {
+        Task { await loadFormats(for: url) }
+    }
+
+    private func loadFormats(for url: URL) async {
+        formatPreviewTitle = url.absoluteString
+        pendingFormatURL = url
+        do {
+            availableFormats = try await manager.availableFormats(for: url)
+            selectedFormat = availableFormats.first
+            isShowingFormatSheet = true
+        } catch {
+            Logger.download.error("Failed to load formats: \(error.localizedDescription)")
+            enqueue(url: url, format: preferenceStore.configuration.formatPreference.ytDlpFormatIdentifier)
+            pendingFormatURL = nil
+        }
+    }
+
+    func confirmFormatSelection() {
+        guard let selectedFormat, let url = pendingFormatURL else { return }
+        enqueue(url: url, format: selectedFormat.id)
+        isShowingFormatSheet = false
+        pendingFormatURL = nil
+        self.selectedFormat = nil
+    }
+
+    func cancelFormatSelection() {
+        isShowingFormatSheet = false
+        pendingFormatURL = nil
+        selectedFormat = nil
+    }
+}

--- a/Sources/ClipperApp/ViewModels/SettingsViewModel.swift
+++ b/Sources/ClipperApp/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,30 @@
+import Combine
+import Foundation
+
+@MainActor
+final class SettingsViewModel: ObservableObject {
+    @Published private(set) var configuration: DownloadConfiguration
+
+    private let preferenceStore: PreferenceStore
+
+    init(preferenceStore: PreferenceStore) {
+        self.preferenceStore = preferenceStore
+        self.configuration = preferenceStore.configuration
+
+        preferenceStore.$configuration
+            .receive(on: RunLoop.main)
+            .assign(to: &self.$configuration)
+    }
+
+    func updateDownloadDirectory(_ url: URL) {
+        preferenceStore.setDownloadDirectory(url)
+    }
+
+    func updateFormatPreference(_ preference: DownloadConfiguration.FormatPreference) {
+        preferenceStore.setFormatPreference(preference)
+    }
+
+    func togglePromptForFormat(_ newValue: Bool) {
+        preferenceStore.setPromptForFormat(newValue)
+    }
+}

--- a/Sources/ClipperApp/Views/ContentView.swift
+++ b/Sources/ClipperApp/Views/ContentView.swift
@@ -1,0 +1,142 @@
+import AppKit
+import SwiftUI
+
+struct ContentView: View {
+    @ObservedObject var viewModel: DownloadQueueViewModel
+    @ObservedObject var settingsViewModel: SettingsViewModel
+
+    var body: some View {
+        NavigationView {
+            sidebar
+            history
+        }
+        .frame(minWidth: 900, minHeight: 560)
+        .sheet(isPresented: $viewModel.isShowingFormatSheet) {
+            if let pendingURL = viewModel.pendingFormatURL {
+                FormatSelectionView(urlString: pendingURL.absoluteString,
+                                     formats: viewModel.availableFormats,
+                                     selectedFormat: Binding(get: {
+                    viewModel.selectedFormat
+                }, set: { newValue in
+                    viewModel.selectedFormat = newValue
+                }),
+                                     confirmAction: {
+                    viewModel.confirmFormatSelection()
+                },
+                                     cancelAction: {
+                    viewModel.cancelFormatSelection()
+                })
+            } else {
+                ProgressView("포맷 정보를 불러오는 중...")
+                    .padding()
+            }
+        }
+    }
+
+    private var sidebar: some View {
+        List {
+            Section("URL 입력") {
+                VStack(spacing: 8) {
+                    TextField("유튜브 URL을 붙여넣고 Enter", text: $viewModel.urlInput)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit { viewModel.submitURL() }
+                    HStack {
+                        Button(action: viewModel.submitURL) {
+                            Label("다운로드 추가", systemImage: "arrow.down.circle")
+                        }
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(viewModel.urlInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        Button(action: pasteFromClipboard) {
+                            Label("클립보드 붙여넣기", systemImage: "doc.on.clipboard")
+                        }
+                    }
+                }
+            }
+
+            if !viewModel.active.isEmpty {
+                Section("다운로드 중") {
+                    ForEach(viewModel.active) { task in
+                        DownloadRowView(task: task,
+                                        cancelAction: { viewModel.cancel(task: task) })
+                    }
+                }
+            }
+
+            if !viewModel.queued.isEmpty {
+                Section("대기열") {
+                    ForEach(viewModel.queued) { task in
+                        DownloadRowView(task: task,
+                                        cancelAction: { viewModel.cancel(task: task) })
+                    }
+                }
+            }
+
+            if viewModel.active.isEmpty && viewModel.queued.isEmpty {
+                Section {
+                    ContentUnavailableView("대기 중인 작업이 없습니다",
+                                            systemImage: "tray",
+                                            description: Text("URL을 추가하면 자동으로 다운로드가 시작됩니다."))
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("다운로드")
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: openSettings) {
+                    Label("설정", systemImage: "gear")
+                }
+            }
+        }
+    }
+
+    private var history: some View {
+        List {
+            Section("완료 내역") {
+                if viewModel.completed.isEmpty {
+                    ContentUnavailableView("완료된 항목이 없습니다",
+                                            systemImage: "clock.arrow.circlepath",
+                                            description: Text("다운로드가 완료되면 이곳에 표시됩니다."))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else {
+                    ForEach(viewModel.completed) { task in
+                        DownloadRowView(task: task,
+                                        retryAction: { viewModel.retry(task: task) },
+                                        openAction: { viewModel.openInFinder(task: task) },
+                                        removeAction: { viewModel.remove(task: task) })
+                    }
+                }
+            }
+        }
+        .navigationTitle("기록")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("기록 비우기") {
+                    viewModel.clearHistory()
+                }
+                .disabled(viewModel.completed.isEmpty)
+            }
+        }
+    }
+
+    private func pasteFromClipboard() {
+        if let clipboard = NSPasteboard.general.string(forType: .string) {
+            viewModel.urlInput = clipboard
+        }
+    }
+
+    private func openSettings() {
+        NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        let preferenceStore = PreferenceStore()
+        let manager = DownloadManager(preferenceStore: preferenceStore,
+                                      notificationManager: NotificationManager.shared)
+        let queueViewModel = DownloadQueueViewModel(manager: manager, preferenceStore: preferenceStore)
+        let settingsViewModel = SettingsViewModel(preferenceStore: preferenceStore)
+        return ContentView(viewModel: queueViewModel, settingsViewModel: settingsViewModel)
+    }
+}

--- a/Sources/ClipperApp/Views/DownloadRowView.swift
+++ b/Sources/ClipperApp/Views/DownloadRowView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+struct DownloadRowView: View {
+    let task: DownloadTask
+    var cancelAction: (() -> Void)?
+    var retryAction: (() -> Void)?
+    var openAction: (() -> Void)?
+    var removeAction: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center) {
+                if let thumbnailURL = task.thumbnailURL {
+                    AsyncImage(url: thumbnailURL) { image in
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    } placeholder: {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.1))
+                            .overlay(
+                                ProgressView()
+                            )
+                    }
+                    .frame(width: 64, height: 36)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayTitle)
+                        .font(.headline)
+                        .lineLimit(2)
+                    Text(task.url.absoluteString)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+                statusControls
+            }
+            progressView
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var progressView: some View {
+        switch task.state {
+        case .queued:
+            Label("대기 중", systemImage: "clock")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        case .preparing:
+            Label("준비 중", systemImage: "bolt.badge.clock")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        case let .downloading(progress, eta):
+            VStack(alignment: .leading, spacing: 4) {
+                ProgressView(value: progress)
+                if let eta {
+                    Text("남은 시간: \(format(eta: eta))")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        case let .finished(fileURL):
+            HStack {
+                Label("완료", systemImage: "checkmark.circle")
+                    .foregroundStyle(.green)
+                Spacer()
+                Button("Finder에서 보기") {
+                    openAction?()
+                }
+                .buttonStyle(.borderless)
+            }
+        case let .failed(reason):
+            HStack {
+                Label("실패", systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+        case .cancelled:
+            Label("취소됨", systemImage: "xmark.circle")
+                .foregroundStyle(.orange)
+        }
+    }
+
+    @ViewBuilder
+    private var statusControls: some View {
+        switch task.state {
+        case .queued, .preparing, .downloading:
+            Button(role: .cancel) {
+                cancelAction?()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+        case .failed:
+            Button("재시도") {
+                retryAction?()
+            }
+            .buttonStyle(.borderless)
+        case .finished:
+            Button(role: .destructive) {
+                removeAction?()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+        case .cancelled:
+            Button(role: .destructive) {
+                removeAction?()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+        }
+    }
+
+    private var displayTitle: String {
+        task.title.isEmpty ? task.url.lastPathComponent : task.title
+    }
+
+    private func format(eta: TimeInterval) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .abbreviated
+        return formatter.string(from: eta) ?? "--"
+    }
+}
+
+struct DownloadRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            DownloadRowView(task: .init(url: URL(string: "https://www.youtube.com/watch?v=dQw4w9WgXcQ")!,
+                                         title: "샘플 다운로드",
+                                         state: .downloading(progress: 0.42, eta: 120)))
+        }
+        .frame(width: 420)
+    }
+}

--- a/Sources/ClipperApp/Views/FormatSelectionView.swift
+++ b/Sources/ClipperApp/Views/FormatSelectionView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct FormatSelectionView: View {
+    let urlString: String
+    let formats: [FormatDescriptor]
+    @Binding var selectedFormat: FormatDescriptor?
+    let confirmAction: () -> Void
+    let cancelAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("포맷 선택")
+                .font(.title2.bold())
+            Text(urlString)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+
+            List(formats) { format in
+                FormatRow(format: format, isSelected: format.id == selectedFormat?.id)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        selectedFormat = format
+                    }
+            }
+            .frame(minHeight: 240)
+
+            HStack {
+                Spacer()
+                Button("취소", role: .cancel) {
+                    cancelAction()
+                }
+                Button("다운로드") {
+                    confirmAction()
+                }
+                .disabled(selectedFormat == nil)
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 480, height: 420)
+    }
+}
+
+private struct FormatRow: View {
+    let format: FormatDescriptor
+    let isSelected: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(format.description)
+                    .font(.body)
+                Text("확장자: .\(format.fileExtension)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if isSelected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.blue)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct FormatSelectionView_Previews: PreviewProvider {
+    @State static var selected: FormatDescriptor? = .init(id: "best",
+                                                          description: "best • 1080p",
+                                                          fileExtension: "mp4",
+                                                          resolution: "1080p",
+                                                          note: "Best quality")
+
+    static var previews: some View {
+        FormatSelectionView(urlString: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                             formats: [selected!],
+                             selectedFormat: $selected,
+                             confirmAction: {},
+                             cancelAction: {})
+    }
+}

--- a/Sources/ClipperApp/Views/SettingsView.swift
+++ b/Sources/ClipperApp/Views/SettingsView.swift
@@ -1,0 +1,71 @@
+import AppKit
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+
+    var body: some View {
+        Form {
+            Section(header: Text("기본 저장 위치")) {
+                HStack {
+                    Text(viewModel.configuration.downloadDirectory.path)
+                        .font(.callout)
+                        .textSelection(.enabled)
+                    Spacer()
+                    Button("변경…") {
+                        selectDownloadDirectory()
+                    }
+                }
+            }
+
+            Section(header: Text("기본 다운로드 포맷")) {
+                Picker("포맷", selection: Binding(get: {
+                    viewModel.configuration.formatPreference == .askEveryTime ? .best : viewModel.configuration.formatPreference
+                }, set: { newValue in
+                    viewModel.updateFormatPreference(newValue)
+                })) {
+                    ForEach(DownloadConfiguration.FormatPreference.allCases.filter { $0 != .askEveryTime }) { preference in
+                        Text(preference.description)
+                            .tag(preference)
+                    }
+                }
+                .pickerStyle(.radioGroup)
+                Toggle("다운로드 시마다 포맷 선택", isOn: Binding(get: {
+                    viewModel.configuration.shouldPromptForFormat
+                }, set: { newValue in
+                    viewModel.togglePromptForFormat(newValue)
+                }))
+            }
+
+            Section(header: Text("도구 상태")) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("앱은 번들된 yt-dlp 및 ffmpeg 바이너리를 사용합니다. 최신 버전으로 교체하려면 개발자 웹사이트에서 제공하는 지침을 따르세요.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+    }
+
+    private func selectDownloadDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.prompt = "선택"
+        panel.directoryURL = viewModel.configuration.downloadDirectory
+        if panel.runModal() == .OK, let url = panel.url {
+            viewModel.updateDownloadDirectory(url)
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let preferenceStore = PreferenceStore()
+        let settingsViewModel = SettingsViewModel(preferenceStore: preferenceStore)
+        SettingsView(viewModel: settingsViewModel)
+    }
+}

--- a/Tests/ClipperAppTests/PlaceholderTests.swift
+++ b/Tests/ClipperAppTests/PlaceholderTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import ClipperApp
+
+final class PlaceholderTests: XCTestCase {
+    func testConfigurationDefaults() {
+        let configuration = DownloadConfiguration.default
+        XCTAssertFalse(configuration.shouldPromptForFormat)
+        XCTAssertEqual(configuration.formatPreference, .best)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold a macOS SwiftUI application targeting Spotlight-based YouTube downloads with an SPM executable target
- implement services for managing yt-dlp/ffmpeg processes, user preferences, Spotlight notifications, and macOS user notifications
- build queue, history, settings, and format selection views backed by observable view models and metadata fetching

## Testing
- not run (macOS-only SwiftUI project; CI environment lacks required frameworks)

------
https://chatgpt.com/codex/tasks/task_e_68cc911ef3a08333a02bb47ca50754cd